### PR TITLE
change link-parsing regex (fixes #4) and an optparse issue

### DIFF
--- a/gscholar/gscholar.py
+++ b/gscholar/gscholar.py
@@ -71,7 +71,7 @@ def query(searchstr, outformat, allresults=False):
 
     # follow the bibtex links to get the bibtex entries
     result = list()
-    if allresults == False:
+    if not allresults:
         tmp = tmp[:1]
     for link in tmp:
         url = GOOGLE_SCHOLAR_URL+link


### PR DESCRIPTION
In my very limited testing, these changes fix #4 by changing the regex parsing in `get_links` to stop on double quotes `"` instead of on tag close `>`.

I also tweaked the options parsing code so that default values for boolean variables are actually booleans, e.g. `False` instead of the string `"False"`.

I've only tested running from the command line to get a single result, but it seems to work:

```
mattjj at deepthought in ~/builds/gscholar on master
○ ./gscholar/gscholar.py "einstein"
@article{einstein1935can,
  title={Can quantum-mechanical description of physical reality be considered complete?},
  author={Einstein, Albert and Podolsky, Boris and Rosen, Nathan},
  journal={Physical review},
  volume={47},
  number={10},
  pages={777},
  year={1935},
  publisher={APS}
}
```

The same command on the current master (640f2d6) gives an HTTP Error 400.
